### PR TITLE
Fix example code on datalog page

### DIFF
--- a/dynamicland/datalog.html
+++ b/dynamicland/datalog.html
@@ -143,7 +143,7 @@
     <div class=code>
 (dl_rule! (reachable ,?x ,?y) :- (edge ,?x ,?z) (reachable ,?z ,?y))
 
-(dl-assert-rule! dl (fresh-vars 2
+(dl-assert-rule! dl (fresh-vars 3
   (lambda (q x y)
     (conj (equalo q `(reachable ,?x ,?y))
           (dl-findo dl ((edge ,?x ,?z) (reachable ,?z ,?y))) )))))))))


### PR DESCRIPTION
This confused me a little, I think the variable count here should be 3, because `q` is also a fresh variable. That would be consistent with `(numvars (+ 1 (length vars))` in the  `dl-rule!` macro later.